### PR TITLE
avax erc1155 nft transfers fix

### DIFF
--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -418,8 +418,8 @@ label_fill_sales AS (
         origin_from_address,
         origin_to_address,
         origin_function_signature,
-        input_data,
         nft_log_id,
+        input_data,
         _log_id,
         GREATEST(
             t._inserted_timestamp,

--- a/models/silver/nft/silver__joepegs_sales.sql
+++ b/models/silver/nft/silver__joepegs_sales.sql
@@ -243,8 +243,7 @@ nft_address_type AS (
     FROM
         {{ ref('silver__nft_transfers') }}
     WHERE
-        block_timestamp :: DATE >= '2022-04-01'
-        AND contract_address IN (
+        contract_address IN (
             SELECT
                 nft_address
             FROM

--- a/models/silver/nft/silver__joepegs_sales.sql
+++ b/models/silver/nft/silver__joepegs_sales.sql
@@ -243,7 +243,8 @@ nft_address_type AS (
     FROM
         {{ ref('silver__nft_transfers') }}
     WHERE
-        contract_address IN (
+        block_timestamp :: DATE >= '2022-04-01'
+        AND contract_address IN (
             SELECT
                 nft_address
             FROM

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -60,7 +60,7 @@ erc721s AS (
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address,
         utils.udf_hex_to_int(
             topics [3] :: STRING
-        ) AS token_id,
+        ) :: STRING AS token_id,
         NULL AS erc1155_value,
         TO_TIMESTAMP_NTZ(_inserted_timestamp) AS _inserted_timestamp,
         event_index
@@ -83,7 +83,7 @@ transfer_singles AS (
         CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS to_address,
         utils.udf_hex_to_int(
             segmented_data [0] :: STRING
-        ) AS token_id,
+        ) :: STRING AS token_id,
         (
             utils.udf_hex_to_int(
                 segmented_data [1] :: STRING
@@ -172,7 +172,7 @@ tokenid_list AS (
         contract_address,
         utils.udf_hex_to_int(
             VALUE :: STRING
-        ) AS tokenId,
+        ) :: STRING AS tokenId,
         ROW_NUMBER() over (
             PARTITION BY tx_hash,
             event_index

--- a/models/silver/nft/silver__salvor_sales.sql
+++ b/models/silver/nft/silver__salvor_sales.sql
@@ -315,7 +315,7 @@ SELECT
     creator_fee_raw,
     platform_fee_raw + creator_fee_raw AS total_fees_raw,
     total_fees_raw + sale_amount_raw AS total_price_raw,
-    'AXAX' AS currency_address,
+    'AVAX' AS currency_address,
     origin_from_address,
     origin_to_address,
     origin_function_signature,


### PR DESCRIPTION
1. Removed `try_to_number` function on erc1155_value and cast it as string instead 
2. Added string cast on tokenId for compatibility with joins with nft models - since nft models usually requires hex to int to get tokenIds
3. Minor fixes in nft models 