### PR TITLE
add precise columns

### DIFF
--- a/models/gold/core/core__ez_avax_transfers.sql
+++ b/models/gold/core/core__ez_avax_transfers.sql
@@ -35,7 +35,9 @@ WITH avax_base AS (
                 '0*$',
                 ''
             )
-        ) AS avax_value_precise
+        ) AS avax_value_precise,
+        tx_position,
+        trace_index
     FROM
         {{ ref('silver__traces') }}
     WHERE
@@ -96,7 +98,9 @@ SELECT
         2
     ) AS amount_usd,
     _call_id,
-    _inserted_timestamp
+    _inserted_timestamp,
+    tx_position,
+    trace_index
 FROM
     avax_base A
     LEFT JOIN {{ ref('silver__prices') }}

--- a/models/gold/core/core__ez_avax_transfers.sql
+++ b/models/gold/core/core__ez_avax_transfers.sql
@@ -1,5 +1,9 @@
 {{ config(
-    materialized = 'view',
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['core','non_realtime'],
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}
@@ -15,45 +19,93 @@ WITH avax_base AS (
         avax_value,
         identifier,
         _call_id,
-        input
+        input,
+        _INSERTED_TIMESTAMP,
+        to_varchar(
+            TO_NUMBER(REPLACE(DATA :value :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :value :: STRING, '0x'))))
+        ) AS avax_value_precise_raw,
+        IFF(LENGTH(avax_value_precise_raw) > 18, LEFT(avax_value_precise_raw, LENGTH(avax_value_precise_raw) - 18) || '.' || RIGHT(avax_value_precise_raw, 18), '0.' || LPAD(avax_value_precise_raw, 18, '0')) AS rough_conversion,
+        IFF(
+            POSITION(
+                '.000000000000000000' IN rough_conversion
+            ) > 0,
+            LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
+            REGEXP_REPLACE(
+                rough_conversion,
+                '0*$',
+                ''
+            )
+        ) AS avax_value_precise
     FROM
         {{ ref('silver__traces') }}
     WHERE
         avax_value > 0
         AND tx_status = 'SUCCESS'
         AND trace_status = 'SUCCESS'
-),
-avax_prices AS (
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
     SELECT
-        HOUR,
-        price AS avax_price
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
     FROM
-        {{ ref('silver__prices') }}
+        {{ this }}
+)
+{% endif %}
+),
+tx_table AS (
+    SELECT
+        block_number,
+        tx_hash,
+        from_address AS origin_from_address,
+        to_address AS origin_to_address,
+        origin_function_signature
+    FROM
+        {{ ref('silver__transactions') }}
     WHERE
-        token_address = '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7'
+        tx_hash IN (
+            SELECT
+                DISTINCT tx_hash
+            FROM
+                avax_base
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '72 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
 )
 SELECT
-    A.tx_hash AS tx_hash,
-    A.block_number AS block_number,
-    A.block_timestamp AS block_timestamp,
-    A.identifier AS identifier,
-    tx.from_address AS origin_from_address,
-    tx.to_address AS origin_to_address,
-    tx.origin_function_signature AS origin_function_signature,
-    A.from_address AS avax_from_address,
-    A.to_address AS avax_to_address,
-    A.avax_value AS amount,
+    tx_hash AS tx_hash,
+    block_number AS block_number,
+    block_timestamp AS block_timestamp,
+    identifier AS identifier,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    from_address AS avax_from_address,
+    to_address AS avax_to_address,
+    avax_value AS amount,
+    avax_value_precise_raw AS amount_precise_raw,
+    avax_value_precise AS amount_precise,
     ROUND(
-        A.avax_value * avax_price,
+        avax_value * price,
         2
-    ) AS amount_usd
+    ) AS amount_usd,
+    _call_id,
+    _inserted_timestamp
 FROM
     avax_base A
-    LEFT JOIN avax_prices
+    LEFT JOIN {{ ref('silver__prices') }}
     ON DATE_TRUNC(
         'hour',
-        block_timestamp
+        A.block_timestamp
     ) = HOUR
-    JOIN {{ ref('silver__transactions') }}
-    tx
-    ON A.tx_hash = tx.tx_hash
+    AND token_address = '0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7'
+    JOIN tx_table USING (
+        tx_hash,
+        block_number
+    )

--- a/models/gold/core/core__fact_traces.sql
+++ b/models/gold/core/core__fact_traces.sql
@@ -11,6 +11,14 @@ SELECT
     from_address,
     to_address,
     avax_value,
+    IFNULL(
+        avax_value_precise_raw,
+        '0'
+    ) AS avax_value_precise_raw,
+    IFNULL(
+        avax_value_precise,
+        '0'
+    ) AS avax_value_precise,
     gas,
     gas_used,
     input,
@@ -24,4 +32,46 @@ SELECT
     error_reason,
     trace_index
 FROM
-    {{ ref('silver__traces') }}
+    (
+        SELECT
+            tx_hash,
+            block_number,
+            block_timestamp,
+            from_address,
+            to_address,
+            avax_value,
+            gas,
+            gas_used,
+            input,
+            output,
+            TYPE,
+            identifier,
+            DATA,
+            tx_status,
+            sub_traces,
+            trace_status,
+            error_reason,
+            trace_index,
+            REPLACE(
+                COALESCE(
+                    DATA :value :: STRING,
+                    DATA :action :value :: STRING
+                ),
+                '0x'
+            ) AS hex,
+            to_varchar(TO_NUMBER(hex, REPEAT('X', LENGTH(hex)))) AS avax_value_precise_raw,
+            IFF(LENGTH(avax_value_precise_raw) > 18, LEFT(avax_value_precise_raw, LENGTH(avax_value_precise_raw) - 18) || '.' || RIGHT(avax_value_precise_raw, 18), '0.' || LPAD(avax_value_precise_raw, 18, '0')) AS rough_conversion,
+            IFF(
+                POSITION(
+                    '.000000000000000000' IN rough_conversion
+                ) > 0,
+                LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
+                REGEXP_REPLACE(
+                    rough_conversion,
+                    '0*$',
+                    ''
+                )
+            ) AS avax_value_precise
+        FROM
+            {{ ref('silver__traces') }}
+    )

--- a/models/gold/core/core__fact_transactions.sql
+++ b/models/gold/core/core__fact_transactions.sql
@@ -14,17 +14,17 @@ SELECT
     origin_function_signature,
     from_address,
     to_address,
-    VALUE AS avax_value,
+    avax_value,
     avax_value_precise_raw,
     avax_value_precise,
     tx_fee,
     tx_fee_precise,
     gas_price,
-    gas AS gas_limit,
+    gas_limit,
     gas_used,
     cumulative_gas_used,
     input_data,
-    tx_status AS status,
+    status,
     effective_gas_price,
     max_fee_per_gas,
     max_priority_fee_per_gas,
@@ -34,4 +34,49 @@ SELECT
     tx_type,
     chain_id
 FROM
-    {{ ref('silver__transactions') }}
+    (
+        SELECT
+            block_number,
+            block_timestamp,
+            block_hash,
+            tx_hash,
+            nonce,
+            POSITION,
+            origin_function_signature,
+            from_address,
+            to_address,
+            VALUE AS avax_value,
+            tx_fee,
+            tx_fee_precise,
+            gas_price,
+            gas AS gas_limit,
+            gas_used,
+            cumulative_gas_used,
+            input_data,
+            tx_status AS status,
+            effective_gas_price,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            r,
+            s,
+            v,
+            tx_type,
+            chain_id,
+            to_varchar(
+                TO_NUMBER(REPLACE(DATA :value :: STRING, '0x'), REPEAT('X', LENGTH(REPLACE(DATA :value :: STRING, '0x'))))
+            ) AS avax_value_precise_raw,
+            IFF(LENGTH(avax_value_precise_raw) > 18, LEFT(avax_value_precise_raw, LENGTH(avax_value_precise_raw) - 18) || '.' || RIGHT(avax_value_precise_raw, 18), '0.' || LPAD(avax_value_precise_raw, 18, '0')) AS rough_conversion,
+            IFF(
+                POSITION(
+                    '.000000000000000000' IN rough_conversion
+                ) > 0,
+                LEFT(rough_conversion, LENGTH(rough_conversion) - 19),
+                REGEXP_REPLACE(
+                    rough_conversion,
+                    '0*$',
+                    ''
+                )
+            ) AS avax_value_precise
+        FROM
+            {{ ref('silver__transactions') }}
+    )

--- a/models/gold/tests/test_gold__ez_avax_transfers_full.sql
+++ b/models/gold/tests/test_gold__ez_avax_transfers_full.sql
@@ -1,0 +1,9 @@
+{{ config (
+    materialized = 'view',
+    tags = ['full_test']
+) }}
+
+SELECT
+    *
+FROM
+    {{ ref('core__ez_avax_transfers') }}

--- a/models/gold/tests/test_gold__ez_avax_transfers_full.yml
+++ b/models/gold/tests/test_gold__ez_avax_transfers_full.yml
@@ -1,6 +1,6 @@
 version: 2
 models:
-  - name: test_gold__ez_AVAX_transfers_full
+  - name: test_gold__ez_avax_transfers_full
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:

--- a/models/gold/tests/test_gold__ez_avax_transfers_full.yml
+++ b/models/gold/tests/test_gold__ez_avax_transfers_full.yml
@@ -1,0 +1,63 @@
+version: 2
+models:
+  - name: test_gold__ez_AVAX_transfers_full
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_NUMBER
+            - TX_POSITION
+            - TRACE_INDEX
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null    
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT      
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ    
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AVAX_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AVAX_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: _CALL_ID
+        tests:
+          - not_null    
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/gold/tests/test_gold__ez_avax_transfers_recent.sql
+++ b/models/gold/tests/test_gold__ez_avax_transfers_recent.sql
@@ -1,0 +1,27 @@
+{{ config (
+    materialized = 'view',
+    tags = ['recent_test']
+) }}
+
+WITH last_3_days AS (
+
+    SELECT
+        block_number
+    FROM
+        {{ ref("_max_block_by_date") }}
+        qualify ROW_NUMBER() over (
+            ORDER BY
+                block_number DESC
+        ) = 3
+)
+SELECT
+    *
+FROM
+    {{ ref('core__ez_avax_transfers') }}
+WHERE
+    block_number >= (
+        SELECT
+            block_number
+        FROM
+            last_3_days
+    )

--- a/models/gold/tests/test_gold__ez_avax_transfers_recent.yml
+++ b/models/gold/tests/test_gold__ez_avax_transfers_recent.yml
@@ -1,0 +1,63 @@
+version: 2
+models:
+  - name: test_gold__ez_avax_transfers_recent
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - BLOCK_NUMBER
+            - TX_POSITION
+            - TRACE_INDEX
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null    
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT      
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ    
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AVAX_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AVAX_TO_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER    
+                - FLOAT
+      - name: _CALL_ID
+        tests:
+          - not_null    
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -88,12 +88,10 @@ base_tx AS (
         A.data :v :: STRING AS v,
         utils.udf_hex_to_int(
             A.data :value :: STRING
-        ) AS avax_value_precise_raw,
-        utils.udf_decimal_adjust(
-            avax_value_precise_raw,
+        ) / pow(
+            10,
             18
-        ) AS avax_value_precise,
-        avax_value_precise :: FLOAT AS VALUE,
+        ) :: FLOAT AS VALUE,
         A._INSERTED_TIMESTAMP,
         A.data
     FROM
@@ -119,8 +117,6 @@ new_records AS (
         t.position,
         t.type,
         t.v,
-        t.avax_value_precise_raw,
-        t.avax_value_precise,
         t.value,
         block_timestamp,
         CASE
@@ -182,8 +178,6 @@ missing_data AS (
         t.position,
         t.type,
         t.v,
-        t.avax_value_precise_raw,
-        t.avax_value_precise,
         t.value,
         b.block_timestamp,
         FALSE AS is_pending,
@@ -239,8 +233,6 @@ FINAL AS (
         TYPE,
         v,
         VALUE,
-        avax_value_precise_raw,
-        avax_value_precise,
         block_timestamp,
         is_pending,
         gas_used,
@@ -278,8 +270,6 @@ SELECT
     TYPE,
     v,
     VALUE,
-    avax_value_precise_raw,
-    avax_value_precise,
     block_timestamp,
     is_pending,
     gas_used,


### PR DESCRIPTION
**`ez_avax_transfers`**
- converts from view to table for performance gains
- adds `avax_value_precise`, `avax_value_precise_raw`, and `_call_id`

**`fact_traces`**
- adds `avax_value_precise_raw` and `avax_value_precise`

`dbt run -m models/silver/core/silver__transactions.sql models/gold/core/core__ez_avax_transfers.sql models/gold/core/core__fact_traces.sql models/gold/core/core__fact_transactions.sql models/gold/tests --full-refresh`