### PR TITLE
AN-3976/delete-insert-reorg

### DIFF
--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -49,5 +49,5 @@ jobs:
   
       - name: Execute block_reorg macro
         run: |
-          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}"
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}" && grep -E "SQL status|/* {" logs/dbt.log
         

--- a/.github/workflows/dbt_run_operation_reorg.yml
+++ b/.github/workflows/dbt_run_operation_reorg.yml
@@ -1,0 +1,53 @@
+name: dbt_run_operation_reorg
+run-name: dbt_run_operation_reorg
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at minute 30 every 8 hours (see https://crontab.guru)
+    - cron: '30 */8 * * *'
+    
+env:
+  DBT_PROFILES_DIR: ./
+
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run_dbt_jobs:
+    runs-on: ubuntu-latest
+    environment: 
+      name: workflow_prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: List reorg models
+        id: list_models
+        run: |
+          reorg_model_list=$(dbt list --select tag:reorg --resource-type model | awk -F'.' '{print $NF}' | tr '\n' ',' | sed 's/,$//')
+          echo "::set-output name=model_list::$reorg_model_list"
+  
+      - name: Execute block_reorg macro
+        run: |
+          dbt run-operation fsc_utils.block_reorg --args "{reorg_model_list: '${{ steps.list_models.outputs.model_list }}', hours: '12'}"
+        

--- a/models/gold/core/core__ez_avax_transfers.sql
+++ b/models/gold/core/core__ez_avax_transfers.sql
@@ -3,10 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['core','non_realtime'],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    tags = ['core','non_realtime','reorg'],
     persist_docs ={ "relation": true,
     "columns": true }
 ) }}

--- a/models/gold/core/core__ez_avax_transfers.sql
+++ b/models/gold/core/core__ez_avax_transfers.sql
@@ -3,6 +3,9 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['core','non_realtime'],
     persist_docs ={ "relation": true,
     "columns": true }

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -4,7 +4,9 @@
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     full_refresh = false,
     tags = ['decoded_logs']
 ) }}

--- a/models/silver/core/silver__decoded_logs.sql
+++ b/models/silver/core/silver__decoded_logs.sql
@@ -4,11 +4,9 @@
     unique_key = ['block_number', 'event_index'],
     cluster_by = "block_timestamp::date",
     incremental_predicates = ["dynamic_range", "block_number"],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     full_refresh = false,
-    tags = ['decoded_logs']
+    tags = ['decoded_logs','reorg']
 ) }}
 
 WITH base_data AS (

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH logs AS (

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -3,6 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = "block_number",
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -1,10 +1,10 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    full_refresh = false
     tags = ['non_realtime']
 ) }}
-
---    full_refresh = false
 
 WITH pools_registered AS (
 
@@ -27,7 +27,7 @@ WITH pools_registered AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -2,7 +2,7 @@
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
-    full_refresh = false
+    full_refresh = false,
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -57,7 +59,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -1,9 +1,10 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    full_refresh = false,
     tags = ['non_realtime']
 ) }}
---    full_refresh = false,
 
 WITH contract_deployments AS (
 
@@ -31,7 +32,7 @@ WHERE
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE - 3
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "_log_id",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -72,7 +74,7 @@ curve_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -119,7 +121,7 @@ token_transfers AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pool_meta AS (

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -62,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
+++ b/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -69,7 +71,7 @@ WITH swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
+++ b/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH swaps_base AS (

--- a/models/silver/dex/hashflow/silver_dex__hashflow_pools.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -26,7 +27,7 @@ WITH contract_deployments AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -70,7 +72,7 @@ router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -134,7 +136,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -36,7 +37,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -67,7 +69,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -42,7 +43,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -67,7 +69,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -33,7 +34,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -80,7 +82,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/pangolin/silver_dex__pangolin_pools.sql
+++ b/models/silver/dex/pangolin/silver_dex__pangolin_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/pangolin/silver_dex__pangolin_swaps.sql
+++ b/models/silver/dex/pangolin/silver_dex__pangolin_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/pangolin/silver_dex__pangolin_swaps.sql
+++ b/models/silver/dex/pangolin/silver_dex__pangolin_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -62,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/platypus/silver_dex__platypus_pools.sql
+++ b/models/silver/dex/platypus/silver_dex__platypus_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -23,7 +24,7 @@ WITH contract_deployments AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/platypus/silver_dex__platypus_swaps.sql
+++ b/models/silver/dex/platypus/silver_dex__platypus_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/platypus/silver_dex__platypus_swaps.sql
+++ b/models/silver/dex/platypus/silver_dex__platypus_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -66,7 +68,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -1,7 +1,9 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = "_id",
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
+  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
   tags = ['non_realtime']
 ) }}
 
@@ -26,6 +28,7 @@ SELECT
     pool_address,
     pool_name,
     'balancer' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp,
     token0,
@@ -42,7 +45,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -59,6 +62,7 @@ SELECT
     pool_address,
     pool_name,
     'curve' AS platform,
+    'v1' AS version,
     _call_id AS _id,
     _inserted_timestamp,
     MAX(CASE WHEN token_num = 1 THEN token_address END) AS token0,
@@ -75,7 +79,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -95,6 +99,7 @@ SELECT
     token0,
     token1,
     'fraxswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -103,7 +108,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -122,6 +127,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v1' AS platform,
+    'v1-dynamic' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -130,7 +136,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -149,6 +155,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v1' AS platform,
+    'v1-static' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -157,7 +164,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -177,6 +184,7 @@ SELECT
     token0,
     token1,
     'kyberswap-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -185,7 +193,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -204,6 +212,7 @@ SELECT
     token0,
     token1,
     'pangolin' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -212,7 +221,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -231,6 +240,7 @@ SELECT
     token0,
     token1,
     'sushiswap' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -239,7 +249,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -258,6 +268,7 @@ SELECT
     token0,
     token1,
     'trader-joe-v1' AS platform,
+    'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -266,7 +277,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -285,6 +296,7 @@ SELECT
     tokenX AS token0,
     tokenY AS token1,
     'trader-joe-v2' AS platform,
+    'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -293,7 +305,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -313,6 +325,7 @@ SELECT
     token0_address AS token0,
     token1_address AS token1,
     'uniswap-v3' AS platform,
+    'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
 FROM
@@ -321,7 +334,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) :: DATE - 1
+      MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
       {{ this }}
   )
@@ -387,6 +400,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_standard p 
@@ -411,6 +425,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_v3 p 
@@ -443,6 +458,7 @@ FINAL AS (
         OBJECT_CONSTRUCT('token0', c0.symbol, 'token1', c1.symbol, 'token2', c2.symbol, 'token3', c3.symbol, 'token4', c4.symbol, 'token5', c5.symbol, 'token6', c6.symbol, 'token7', c7.symbol) AS symbols,
         OBJECT_CONSTRUCT('token0', c0.decimals, 'token1', c1.decimals, 'token2', c2.decimals, 'token3', c3.decimals, 'token4', c4.decimals, 'token5', c5.decimals, 'token6', c6.decimals, 'token7', c7.decimals) AS decimals,
         platform,
+        version,
         _id,
         p._inserted_timestamp
     FROM all_pools_other p
@@ -469,6 +485,7 @@ SELECT
     block_timestamp,
     tx_hash,
     platform,
+    version,
     contract_address,
     pool_address,
     pool_name,

--- a/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -3,8 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-  tags = ['non_realtime']
+  tags = ['non_realtime','reorg']
 ) }}
 
 WITH contracts AS (

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -62,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "pool_address",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -30,7 +31,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -62,7 +64,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -84,7 +86,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = "lb_pair",
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     tags = ['non_realtime']
 ) }}
 
@@ -37,7 +38,7 @@ WITH pool_creation AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH pools AS (

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -83,7 +85,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = 'block_number',
+    unique_key = 'created_block',
     cluster_by = ['_inserted_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'pool_address',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['_inserted_timestamp::DATE'],
     tags = ['non_realtime']
 ) }}
@@ -35,9 +36,7 @@ WITH created_pools AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -61,9 +60,7 @@ initial_info AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base_swaps AS (

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -43,9 +45,7 @@ WITH base_swaps AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 2
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH router_swaps_base AS (

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -67,7 +69,7 @@ WITH router_swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )
@@ -138,7 +140,7 @@ swaps_base AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(_inserted_timestamp) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__complete_nft_sales.sql
+++ b/models/silver/nft/silver__complete_nft_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform_name','platform_exchange_version'],
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH nft_base_models AS (

--- a/models/silver/nft/silver__joepegs_sales.sql
+++ b/models/silver/nft/silver__joepegs_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH raw_decoded_logs AS (

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -3,10 +3,8 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    post_hook = [
-        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
-        "{{ fsc_utils.block_reorg(this, 12) }}"],
-    tags = ['non_realtime']
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH base AS (

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -1,9 +1,11 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = '_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE', '_inserted_timestamp::DATE'],
-    merge_update_columns = ["_log_id"],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+    post_hook = [
+        "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(contract_address, tx_hash)",
+        "{{ fsc_utils.block_reorg(this, 12) }}"],
     tags = ['non_realtime']
 ) }}
 

--- a/models/silver/nft/silver__salvor_sales.sql
+++ b/models/silver/nft/silver__salvor_sales.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -31,9 +33,7 @@ WITH raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -267,9 +267,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__salvor_sales.sql
+++ b/models/silver/nft/silver__salvor_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH raw_logs AS (

--- a/models/silver/nft/silver__seaport_1_1_sales.sql
+++ b/models/silver/nft/silver__seaport_1_1_sales.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -31,9 +33,7 @@ seaport_tx_table AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -74,9 +74,7 @@ decoded AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1051,9 +1049,7 @@ tx_data AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1094,9 +1090,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_1_sales.sql
+++ b/models/silver/nft/silver__seaport_1_1_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH seaport_fees_wallet AS (

--- a/models/silver/nft/silver__seaport_1_4_sales.sql
+++ b/models/silver/nft/silver__seaport_1_4_sales.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -30,9 +32,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -90,9 +90,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1656,9 +1654,7 @@ mao_orderhash AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1699,9 +1695,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_4_sales.sql
+++ b/models/silver/nft/silver__seaport_1_4_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH seaport_fees_wallet AS (

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -1,7 +1,9 @@
 {{ config(
     materialized = 'incremental',
-    unique_key = 'nft_log_id',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
+    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
     tags = ['non_realtime']
 ) }}
 
@@ -29,9 +31,7 @@ raw_decoded_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -91,9 +91,7 @@ raw_logs AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1689,9 +1687,7 @@ mao_orderhash AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )
@@ -1732,9 +1728,7 @@ nft_transfer_operator AS (
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
-        MAX(
-            _inserted_timestamp
-        ) :: DATE - 1
+        MAX(_inserted_timestamp) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/models/silver/nft/silver__seaport_1_5_sales.sql
+++ b/models/silver/nft/silver__seaport_1_5_sales.sql
@@ -3,8 +3,7 @@
     incremental_strategy = 'delete+insert',
     unique_key = 'block_number',
     cluster_by = ['block_timestamp::DATE'],
-    post_hook = "{{ fsc_utils.block_reorg(this, 12) }}",
-    tags = ['non_realtime']
+    tags = ['non_realtime','reorg']
 ) }}
 
 WITH seaport_fees_wallet AS (

--- a/models/silver/prices/silver__hourly_prices_priority.sql
+++ b/models/silver/prices/silver__hourly_prices_priority.sql
@@ -31,7 +31,7 @@ AND p._inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) :: DATE - 1
+        ) - INTERVAL '24 hours'
     FROM
         {{ this }}
 )

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.6.0
+    revision: v1.6.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.5.0
+    revision: v1.6.0
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
1. Changes incremental strategy to delete+insert on `block_number` in majority of logs based downstream models
2. Minimizes incremental lookback to rolling 12-24 hrs vs 1-3 days, with exceptions
3. FR required on complete_dex_swaps, complete_dex_liquidity_pools to add `version` columns
4. Adds new workflow for block reorg macro, scheduled to run 3x daily - based on `reorg` tag