### PR TITLE
reenable test, remove try to number

### DIFF
--- a/models/silver/nft/silver__complete_nft_sales.yml
+++ b/models/silver/nft/silver__complete_nft_sales.yml
@@ -41,6 +41,11 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: BUYER_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
       - name: NFT_ADDRESS
         tests:
           - not_null

--- a/models/silver/nft/silver__salvor_sales.sql
+++ b/models/silver/nft/silver__salvor_sales.sql
@@ -75,11 +75,9 @@ payout_raw AS (
             40
         ) AS nft_owner,
         -- payout receiver
-        TRY_TO_NUMBER(
-            utils.udf_hex_to_int(
-                segmented_data [0] :: STRING
-            )
-        ) AS sale_amount_raw,
+        utils.udf_hex_to_int(
+            segmented_data [0] :: STRING
+        ) :: INT AS sale_amount_raw,
         CONCAT(
             tx_hash,
             '-',
@@ -120,16 +118,12 @@ commission_raw AS (
             25,
             40
         ) AS nft_owner,
-        TRY_TO_NUMBER(
-            utils.udf_hex_to_int(
-                segmented_data [1] :: STRING
-            )
-        ) AS platform_fee_raw,
-        TRY_TO_NUMBER(
-            utils.udf_hex_to_int(
-                segmented_data [2] :: STRING
-            )
-        ) AS total_price_raw,
+        utils.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS platform_fee_raw,
+        utils.udf_hex_to_int(
+            segmented_data [2] :: STRING
+        ) :: INT AS total_price_raw,
         segmented_data
     FROM
         raw_logs
@@ -161,7 +155,7 @@ royalty_raw AS (
         ) AS nft_owner,
         utils.udf_hex_to_int(
             segmented_data [1] :: STRING
-        ) AS creator_fee_raw_,
+        ) :: INT AS creator_fee_raw_,
         CONCAT(
             tx_hash,
             '-',

--- a/models/silver/nft/silver__salvor_sales.yml
+++ b/models/silver/nft/silver__salvor_sales.yml
@@ -41,6 +41,11 @@ models:
           - not_null
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: 0[xX][0-9a-fA-F]+
+      - name: BUYER_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
       - name: NFT_ADDRESS
         tests:
           - not_null


### PR DESCRIPTION
For salvor sales nft model: 
1. Reenable test for null buyer address 
2. Remove try_to_number cast 