### PR TITLE
AN-4411/gmx-fees

### DIFF
--- a/models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql
+++ b/models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql
@@ -9,19 +9,19 @@
 WITH swaps_base AS (
 
     SELECT
-        l.block_number,
-        l.block_timestamp,
-        l.tx_hash,
+        block_number,
+        block_timestamp,
+        tx_hash,
         origin_function_signature,
         origin_from_address,
         origin_to_address,
-        l.event_index,
-        l.contract_address,
-        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT(
             '0x',
             SUBSTR(
-                l_segmented_data [0] :: STRING,
+                segmented_data [0] :: STRING,
                 25,
                 40
             )
@@ -29,7 +29,7 @@ WITH swaps_base AS (
         CONCAT(
             '0x',
             SUBSTR(
-                l_segmented_data [1] :: STRING,
+                segmented_data [1] :: STRING,
                 25,
                 40
             )
@@ -37,35 +37,38 @@ WITH swaps_base AS (
         CONCAT(
             '0x',
             SUBSTR(
-                l_segmented_data [2] :: STRING,
+                segmented_data [2] :: STRING,
                 25,
                 40
             )
         ) AS tokenOut,
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
-                l_segmented_data [3] :: STRING
+                segmented_data [3] :: STRING
             )
         ) AS amountIn,
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
-                l_segmented_data [4] :: STRING
+                segmented_data [4] :: STRING
             )
         ) AS amountOut,
-        l._log_id,
-        l._inserted_timestamp
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [5] :: STRING
+            )
+        ) AS amountOutAfterFees,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [6] :: STRING
+            )
+        ) AS feeBasisPoints,
+        _log_id,
+        _inserted_timestamp
     FROM
         {{ ref('silver__logs') }}
-        l
     WHERE
-        contract_address IN (
-            '0x5f719c2f1095f7b9fc68a68e35b51194f4b6abe8',
-            '0x9ab2de34a33fb459b538c43f251eb825645e8595'
-        )
-        AND topics [0] :: STRING IN (
-            '0xcd3829a3813dc3cdd188fd3d01dcf3268c16be2fdd2dd21d0665418816e46062',
-            '0x0874b2d545cb271cdbda4e093020c452328b24af12382ed62c4d00f5c26709db'
-        ) --Swap
+        contract_address = '0x9ab2de34a33fb459b538c43f251eb825645e8595'
+        AND topics [0] :: STRING = '0x0874b2d545cb271cdbda4e093020c452328b24af12382ed62c4d00f5c26709db'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -90,7 +93,7 @@ SELECT
     tokenIn AS token_in,
     tokenOut AS token_out,
     amountIn AS amount_in_unadj,
-    amountOut AS amount_out_unadj,
+    amountOutAfterFees AS amount_out_unadj,
     'Swap' AS event_name,
     'gmx' AS platform,
     _log_id,

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -73,7 +73,7 @@ balancer_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'balancer_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -125,7 +125,7 @@ trader_joe_v1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'trader_joe_v1_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -177,7 +177,7 @@ trader_joe_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'trader_joe_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -229,7 +229,7 @@ trader_joe_v2_1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'trader_joe_v2_1_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -303,7 +303,7 @@ woofi_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'woofi_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -377,7 +377,7 @@ gmx_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'gmx_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -429,7 +429,7 @@ kyberswap_v1_dynamic AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -481,7 +481,7 @@ kyberswap_v1_static AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -533,7 +533,7 @@ kyberswap_v2_elastic AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -585,7 +585,7 @@ pangolin_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'pangolin_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -659,7 +659,7 @@ platypus_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'platypus_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -711,7 +711,7 @@ fraxswap_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'fraxswap_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -785,7 +785,7 @@ hashflow_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'hashflow_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -859,7 +859,7 @@ hashflow_v3_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'hashflow_v3_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -911,7 +911,7 @@ sushi_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'sushi_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -981,7 +981,7 @@ curve_swaps AS (
       'null'
     ) <> COALESCE(token_symbol_out, 'null')
 
-{% if is_incremental() %}
+{% if is_incremental() and 'curve_swaps' not in var('HEAL_CURATED_MODEL') %}
 AND _inserted_timestamp >= (
   SELECT
     MAX(_inserted_timestamp) - INTERVAL '36 hours'
@@ -1082,7 +1082,7 @@ univ3_swaps AS (
       block_timestamp
     ) = p2.hour
 
-{% if is_incremental() %}
+{% if is_incremental() and 'univ3_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT


### PR DESCRIPTION
1. Resolves bug in gmx swaps causing double counting / amount before fees
2. Adds heal variable to complete

`dbt run -m models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql --full-refresh && dbt run -m models/silver/defi/dex/silver_dex__complete_dex_swaps.sql --var '{"HEAL_CURATED_MODEL":"gmx_swaps"}'`