### PR TITLE
AN-5012/node-path

### DIFF
--- a/models/dexalot/silver/silver_dexalot__logs.sql
+++ b/models/dexalot/silver/silver_dexalot__logs.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = "logs_id",
+    unique_key = "block_number",
     cluster_by = "block_timestamp::date, _inserted_timestamp::date",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     tags = ['dexalot_non_realtime']

--- a/models/dexalot/silver/silver_dexalot__receipts.sql
+++ b/models/dexalot/silver/silver_dexalot__receipts.sql
@@ -1,4 +1,4 @@
--- depends_on: {{ ref('bronze_dexalot__receipts_by_hash') }}
+-- depends_on: {{ ref('bronze_dexalot__receipts') }}
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
@@ -23,7 +23,7 @@ WITH base AS (
     FROM
 
 {% if is_incremental() %}
-{{ ref('bronze_dexalot__receipts_by_hash') }}
+{{ ref('bronze_dexalot__receipts') }}
 WHERE
     _inserted_timestamp >= (
         SELECT
@@ -33,7 +33,7 @@ WHERE
     )
     AND IS_OBJECT(DATA)
 {% else %}
-    {{ ref('bronze_dexalot__FR_receipts_by_hash') }}
+    {{ ref('bronze_dexalot__FR_receipts') }}
 WHERE
     IS_OBJECT(DATA)
 {% endif %}

--- a/models/dexalot/silver/silver_dexalot__receipts.sql
+++ b/models/dexalot/silver/silver_dexalot__receipts.sql
@@ -2,9 +2,9 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = "tx_hash",
+    unique_key = "block_number",
     cluster_by = "ROUND(block_number, -3)",
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(tx_hash)",
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION ON EQUALITY(block_hash, tx_hash, from_address, to_address)",
     tags = ['dexalot_non_realtime']
 ) }}
 
@@ -18,7 +18,7 @@ WITH base AS (
                 metadata :request :"data"
             ) :id :: INT
         ) AS block_number,
-        DATA :result AS DATA,
+        DATA,
         _inserted_timestamp
     FROM
 

--- a/models/dexalot/silver/silver_dexalot__transactions.sql
+++ b/models/dexalot/silver/silver_dexalot__transactions.sql
@@ -2,7 +2,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
-    unique_key = "transactions_id",
+    unique_key = "block_number",
     cluster_by = "block_timestamp::date, _inserted_timestamp::date",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
     tags = ['dexalot_non_realtime']

--- a/models/dexalot/streamline/core/complete/streamline__dexalot_receipts_by_hash_complete.sql
+++ b/models/dexalot/streamline/core/complete/streamline__dexalot_receipts_by_hash_complete.sql
@@ -4,7 +4,7 @@
     unique_key = "complete_receipts_by_hash_id",
     cluster_by = "ROUND(block_number, -3)",
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(complete_receipts_by_hash_id)",
-    tags = ['streamline_dexalot_complete']
+    tags = ['stale']
 ) }}
 
 SELECT

--- a/models/dexalot/streamline/core/complete/streamline__dexalot_receipts_complete.sql
+++ b/models/dexalot/streamline/core/complete/streamline__dexalot_receipts_complete.sql
@@ -6,6 +6,16 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)"
 ) }}
 
+SELECT 
+    block_number,
+    complete_receipts_by_hash_id AS complete_receipts_id,
+    inserted_timestamp,
+    modified_timestamp,
+    _inserted_timestamp,
+    _invocation_id
+FROM {{ ref('streamline__dexalot_receipts_by_hash_complete')}}
+{# WHERE 1=2 #} --add after FR
+UNION ALL
 SELECT
     VALUE :BLOCK_NUMBER :: INT AS block_number,
     {{ dbt_utils.generate_surrogate_key(

--- a/models/dexalot/streamline/core/complete/streamline__dexalot_receipts_complete.sql
+++ b/models/dexalot/streamline/core/complete/streamline__dexalot_receipts_complete.sql
@@ -6,15 +6,20 @@
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION on equality(block_number)"
 ) }}
 
-SELECT 
+SELECT
     block_number,
     complete_receipts_by_hash_id AS complete_receipts_id,
     inserted_timestamp,
     modified_timestamp,
     _inserted_timestamp,
     _invocation_id
-FROM {{ ref('streamline__dexalot_receipts_by_hash_complete')}}
-{# WHERE 1=2 #} --add after FR
+FROM
+    {{ ref('streamline__dexalot_receipts_by_hash_complete') }}
+
+{% if is_incremental() %}
+WHERE
+    1 = 2
+{% endif %}
 UNION ALL
 SELECT
     VALUE :BLOCK_NUMBER :: INT AS block_number,

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_blocks_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_blocks_realtime.sql
@@ -61,7 +61,7 @@ SELECT
     ) :: INT AS partition_key,
     {{ target.database }}.live.udf_api(
         'POST',
-        'https://subnets.avax.network/dexalot/mainnet/rpc',
+        '{Service}',
         OBJECT_CONSTRUCT(
             'Content-Type',
             'application/json'
@@ -75,7 +75,7 @@ SELECT
             'eth_getBlockByNumber',
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), FALSE)),
-            ''
+            'Vault/prod/avalanche/dexalot/internal'
         ) AS request
         FROM
             ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_blocks_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_blocks_realtime.sql
@@ -75,7 +75,7 @@ SELECT
             'eth_getBlockByNumber',
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), FALSE)),
-            'Vault/prod/avalanche/dexalot/internal'
+            'Vault/prod/avalanche/dexalot/internal/mainnet'
         ) AS request
         FROM
             ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_by_hash_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_by_hash_realtime.sql
@@ -66,7 +66,7 @@ SELECT
     ) :: INT AS partition_key,
     {{ target.database }}.live.udf_api(
         'POST',
-        'https://subnets.avax.network/dexalot/mainnet/rpc',
+        '{Service}',
         OBJECT_CONSTRUCT(
             'Content-Type',
             'application/json'
@@ -81,7 +81,7 @@ SELECT
             'params',
             ARRAY_CONSTRUCT(tx_hash)
         ),
-        ''
+        'Vault/prod/avalanche/dexalot/internal'
     ) AS request
 FROM
     ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_by_hash_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_by_hash_realtime.sql
@@ -9,7 +9,7 @@
         "worker_batch_size" :"2000",
         "sql_source" :"{{this.identifier}}" }
     ),
-    tags = ['streamline_dexalot_realtime']
+    tags = ['stale']
 ) }}
 
 WITH last_3_days AS (
@@ -81,7 +81,7 @@ SELECT
             'params',
             ARRAY_CONSTRUCT(tx_hash)
         ),
-        'Vault/prod/avalanche/dexalot/internal'
+        'Vault/prod/avalanche/dexalot/internal/mainnet'
     ) AS request
 FROM
     ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_realtime.sql
@@ -9,7 +9,8 @@
         "worker_batch_size" :"1000",
         "sql_source" :"{{this.identifier}}",
         "exploded_key": tojson(["result"]) }
-    )
+    ),
+    tags = ['streamline_dexalot_realtime']
 ) }}
 
 WITH last_3_days AS (
@@ -52,8 +53,6 @@ ready_blocks AS (
         block_number
     FROM
         to_do
-    LIMIT
-        10
 )
 SELECT
     block_number,
@@ -77,9 +76,10 @@ SELECT
             'eth_getBlockReceipts',
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number))),
-            'Vault/prod/avalanche/dexalot/internal'
+            'Vault/prod/avalanche/dexalot/internal/mainnet'
         ) AS request
         FROM
             ready_blocks
         ORDER BY
             block_number DESC
+    LIMIT 10

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_realtime.sql
@@ -63,7 +63,7 @@ SELECT
     ) :: INT AS partition_key,
     {{ target.database }}.live.udf_api(
         'POST',
-        'https://subnets.avax.network/dexalot/mainnet/rpc',
+        '{Service}',
         OBJECT_CONSTRUCT(
             'Content-Type',
             'application/json'
@@ -77,7 +77,7 @@ SELECT
             'eth_getBlockReceipts',
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number))),
-            ''
+            'Vault/prod/avalanche/dexalot/internal'
         ) AS request
         FROM
             ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_receipts_realtime.sql
@@ -82,4 +82,3 @@ SELECT
             ready_blocks
         ORDER BY
             block_number DESC
-    LIMIT 10

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_traces_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_traces_realtime.sql
@@ -78,7 +78,7 @@ SELECT
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), OBJECT_CONSTRUCT('tracer', 'fastCallTracer', 'timeout', '180s'))
         ),
-        'Vault/prod/avalanche/dexalot/internal'
+        'Vault/prod/avalanche/dexalot/internal/mainnet'
     ) AS request
 FROM
     ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_traces_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_traces_realtime.sql
@@ -63,7 +63,7 @@ SELECT
     ) :: INT AS partition_key,
     {{ target.database }}.live.udf_api(
         'POST',
-        'https://subnets.avax.network/dexalot/mainnet/rpc',
+        '{Service}',
         OBJECT_CONSTRUCT(
             'Content-Type',
             'application/json'
@@ -78,7 +78,7 @@ SELECT
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), OBJECT_CONSTRUCT('tracer', 'fastCallTracer', 'timeout', '180s'))
         ),
-        ''
+        'Vault/prod/avalanche/dexalot/internal'
     ) AS request
 FROM
     ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_transactions_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_transactions_realtime.sql
@@ -62,7 +62,7 @@ SELECT
     ) :: INT AS partition_key,
     {{ target.database }}.live.udf_api(
         'POST',
-        'https://subnets.avax.network/dexalot/mainnet/rpc',
+        '{Service}',
         OBJECT_CONSTRUCT(
             'Content-Type',
             'application/json'
@@ -76,7 +76,7 @@ SELECT
             'eth_getBlockByNumber',
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), TRUE)),
-            ''
+            'Vault/prod/avalanche/dexalot/internal'
         ) AS request
         FROM
             ready_blocks

--- a/models/dexalot/streamline/core/realtime/streamline__dexalot_transactions_realtime.sql
+++ b/models/dexalot/streamline/core/realtime/streamline__dexalot_transactions_realtime.sql
@@ -76,7 +76,7 @@ SELECT
             'eth_getBlockByNumber',
             'params',
             ARRAY_CONSTRUCT(utils.udf_int_to_hex(block_number), TRUE)),
-            'Vault/prod/avalanche/dexalot/internal'
+            'Vault/prod/avalanche/dexalot/internal/mainnet'
         ) AS request
         FROM
             ready_blocks

--- a/models/dexalot/streamline/streamline__get_dexalot_chainhead.sql
+++ b/models/dexalot/streamline/streamline__get_dexalot_chainhead.sql
@@ -23,7 +23,7 @@ SELECT
             'params',
             []
         ),
-        'Vault/prod/avalanche/dexalot/internal'
+        'Vault/prod/avalanche/dexalot/internal/mainnet'
     ) AS resp,
     utils.udf_hex_to_int(
         resp :data :result :: STRING

--- a/models/dexalot/streamline/streamline__get_dexalot_chainhead.sql
+++ b/models/dexalot/streamline/streamline__get_dexalot_chainhead.sql
@@ -6,7 +6,7 @@
 SELECT
     {{ target.database }}.live.udf_api(
         'POST',
-        'https://subnets.avax.network/dexalot/mainnet/rpc',
+        '{Service}',
         OBJECT_CONSTRUCT(
             'Content-Type',
             'application/json',
@@ -23,7 +23,7 @@ SELECT
             'params',
             []
         ),
-        ''
+        'Vault/prod/avalanche/dexalot/internal'
     ) AS resp,
     utils.udf_hex_to_int(
         resp :data :result :: STRING

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -6,11 +6,11 @@ packages:
 - package: dbt-labs/dbt_utils
   version: 1.0.0
 - git: https://github.com/FlipsideCrypto/fsc-utils.git
-  revision: 12aed56282bf1d03542f28986e6cf3e7a656b8e5
+  revision: 375c069b870687522501da7716efa90bc70815b5
 - package: get-select/dbt_snowflake_query_tags
   version: 2.5.0
 - package: calogica/dbt_date
   version: 0.7.2
 - git: https://github.com/FlipsideCrypto/livequery-models.git
   revision: b024188be4e9c6bc00ed77797ebdc92d351d620e
-sha1_hash: ba07115c2b2c4e62c0402eb953ea6f9c7f7900e5
+sha1_hash: d8b9012bc389309de111f641a07d01d478cfea66


### PR DESCRIPTION
1. Upgrades to Dexalot Internal Node from Public Node
2. Updates receipts model to `eth_getBlockReceipts`

`dbt run -m models/dexalot/streamline/core/complete/streamline__dexalot_receipts_complete.sql models/dexalot/bronze/bronze_dexalot__FR_receipts.sql models/dexalot/bronze/bronze_dexalot__receipts.sql --full-refresh`