### PR TITLE
Update fsc utils version + fix ABI api requests 

### DIFF
--- a/models/bronze/api_udf/bronze_api__contract_abis.sql
+++ b/models/bronze/api_udf/bronze_api__contract_abis.sql
@@ -50,8 +50,15 @@ row_nos AS (
 ),
 batched AS ({% for item in range(101) %}
 SELECT
-    rn.contract_address, live.udf_api('GET', CONCAT('https://api.routescan.io/v2/network/mainnet/evm/', '43114', --avax C-chain ID
-    '/etherscan/api?module=contract&action=getabi&address=', contract_address, '&apikey=none'),{ 'User-Agent': 'FlipsideStreamline' },{}) AS abi_data, SYSDATE() AS _inserted_timestamp
+    rn.contract_address, 
+    live.udf_api('GET', 
+    CONCAT('https://api.routescan.io/v2/network/mainnet/evm/', '43114', --avax C-chain ID
+    '/etherscan/api?module=contract&action=getabi&address=', 
+    contract_address, '&apikey=none'),
+    { 'User-Agent': 'FlipsideStreamline' },
+    null
+    ) AS abi_data, 
+    SYSDATE() AS _inserted_timestamp
 FROM
     row_nos rn
 WHERE

--- a/models/bronze/api_udf/bronze_api__contract_abis.sql
+++ b/models/bronze/api_udf/bronze_api__contract_abis.sql
@@ -55,8 +55,12 @@ SELECT
     CONCAT('https://api.routescan.io/v2/network/mainnet/evm/', '43114', --avax C-chain ID
     '/etherscan/api?module=contract&action=getabi&address=', 
     contract_address, '&apikey=none'),
-    { 'User-Agent': 'FlipsideStreamline' },
-    null
+    OBJECT_CONSTRUCT(
+            'Content-Type', 'application/json',
+            'fsc-quantum-state', 'livequery'
+        ),
+        NULL,
+        ''
     ) AS abi_data, 
     SYSDATE() AS _inserted_timestamp
 FROM

--- a/packages.yml
+++ b/packages.yml
@@ -6,7 +6,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.31.0
+    revision: v1.33.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]
   - git: https://github.com/FlipsideCrypto/fsc-evm.git


### PR DESCRIPTION
steps:

-- delete from avalanche.bronze_api.contract_abis
--where _inserted_timestamp >= '2024-11-27 11:36:12.000';

-- DROP SCHEMA avalanche._live;
-- DROP SCHEMA avalanche._utils;
-- DROP SCHEMA avalanche.live;
-- DROP SCHEMA avalanche.utils;

dbt run -m livequery_models.deploy.core --vars '{UPDATE_UDFS_AND_SPS: true}' --target prod

SHOW GRANTS ON FUNCTION avalanche._LIVE.UDF_API(VARCHAR, VARCHAR, OBJECT, VARIANT, VARCHAR, VARCHAR);
-- GRANT USAGE ON SCHEMA avalanche._live TO AWS_LAMBDA_avalanche_API; 
-- GRANT USAGE ON ALL FUNCTIONS IN SCHEMA avalanche._live TO AWS_LAMBDA_avalanche_API;
-- GRANT USAGE ON SCHEMA avalanche._live TO DBT_CLOUD_avalanche; 
-- GRANT USAGE ON ALL FUNCTIONS IN SCHEMA avalanche._live TO DBT_CLOUD_avalanche; 
SHOW GRANTS ON FUNCTION avalanche._UTILS.UDF_INTROSPECT(VARCHAR);
-- GRANT USAGE ON SCHEMA avalanche._utils TO AWS_LAMBDA_avalanche_API; 
-- GRANT USAGE ON ALL FUNCTIONS IN SCHEMA avalanche._utils TO AWS_LAMBDA_avalanche_API;
-- GRANT USAGE ON SCHEMA avalanche._utils TO DBT_CLOUD_avalanche; 
-- GRANT USAGE ON ALL FUNCTIONS IN SCHEMA avalanche._utils TO DBT_CLOUD_avalanche; 
